### PR TITLE
[ci] shut down dotnet process

### DIFF
--- a/.github/workflows/dotnes.yml
+++ b/.github/workflows/dotnes.yml
@@ -27,6 +27,8 @@ jobs:
         dotnet new nes --output samples/foo && \
         dotnet build samples/foo/foo.csproj -bl:foo-debug.binlog && \
         dotnet build samples/foo/foo.csproj -c Release -bl:foo-release.binlog
+    - name: shutdown
+      run: dotnet build-server shutdown
     - name: upload logs
       if: always()
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes message in logs:

    Cleaning up orphan processes
    Terminate orphan process: pid (3460) (dotnet)