### PR TITLE
[ci] update gh actions versions

### DIFF
--- a/.github/workflows/dotnes.yml
+++ b/.github/workflows/dotnes.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: build
@@ -31,14 +31,14 @@ jobs:
       run: dotnet build-server shutdown
     - name: upload logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: '*.binlog'
         if-no-files-found: error
     - name: upload ROMs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ROMs
         path: |
@@ -47,7 +47,7 @@ jobs:
         if-no-files-found: error
     - name: upload nupkgs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nupkgs
         path: |


### PR DESCRIPTION
Fixes warning:

    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-dotnet@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.