### PR TITLE
encode vector addresses in code

### DIFF
--- a/src/dotnes.tasks/Utilities/NESWriter.cs
+++ b/src/dotnes.tasks/Utilities/NESWriter.cs
@@ -167,6 +167,15 @@ class NESWriter(Stream stream, bool leaveOpen = false, ILogger? logger = null) :
         _writer.Write(buffer);
     }
 
+    public void Write(ushort[] buffer)
+    {
+        LastLDA = false;
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            _writer.Write(buffer[i]);
+        }
+    }
+
     public void Write(byte[] buffer, int index, int count)
     {
         LastLDA = false;

--- a/src/dotnes.tasks/Utilities/Transpiler.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.cs
@@ -139,10 +139,15 @@ class Transpiler : IDisposable
         // Pad 0s
         int PRG_ROM_SIZE = (int)writer.Length - 16;
         writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - (PRG_ROM_SIZE % NESWriter.PRG_ROM_BLOCK_SIZE));
-        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - 6);
 
-        //TODO: no idea what these are???
-        writer.Write([0xBC, 0x80, 0x00, 0x80, 0x02, 0x82]);
+        // Write interrupt vectors
+        const int VECTOR_ADDRESSES_SIZE = 6;
+        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - VECTOR_ADDRESSES_SIZE);
+        ushort nmi_data = 0x80BC;
+        ushort reset_data = 0x8000;
+        ushort irq_data = 0x8202;
+        writer.Write(new ushort[] { nmi_data, reset_data, irq_data });
+
         _logger.WriteLine($"Writing chr_rom...");
         writer.Write(chr_rom.Bytes);
         // Pad remaining zeros

--- a/src/dotnes.tests/IL2NESWriterTests.cs
+++ b/src/dotnes.tests/IL2NESWriterTests.cs
@@ -82,10 +82,14 @@ public class IL2NESWriterTests
         // Pad 0s
         int PRG_ROM_SIZE = (int)writer.Length - 16;
         writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - (PRG_ROM_SIZE % NESWriter.PRG_ROM_BLOCK_SIZE));
-        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - 6);
 
-        //TODO: no idea what these are???
-        writer.Write(new byte[] { 0xBC, 0x80, 0x00, 0x80, 0x02, 0x82 });
+        // Write interrupt vectors
+        const int VECTOR_ADDRESSES_SIZE = 6;
+        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - VECTOR_ADDRESSES_SIZE);
+        ushort nmi_data = 0x80BC;
+        ushort reset_data = 0x8000;
+        ushort irq_data = 0x8202;
+        writer.Write(new ushort[] { nmi_data, reset_data, irq_data });
 
         // Use CHR_ROM from hello.nes
         writer.Write(data, (int)writer.Length, NESWriter.CHR_ROM_BLOCK_SIZE);

--- a/src/dotnes.tests/NESWriterTests.cs
+++ b/src/dotnes.tests/NESWriterTests.cs
@@ -304,10 +304,14 @@ public class NESWriterTests
         // Pad 0s
         int PRG_ROM_SIZE = (int)writer.Length - 16;
         writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - (PRG_ROM_SIZE % NESWriter.PRG_ROM_BLOCK_SIZE));
-        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - 6);
 
-        //TODO: no idea what these are???
-        writer.Write(new byte[] { 0xBC, 0x80, 0x00, 0x80, 0x02, 0x82 });
+        // Write interrupt vectors
+        const int VECTOR_ADDRESSES_SIZE = 6;
+        writer.WriteZeroes(NESWriter.PRG_ROM_BLOCK_SIZE - VECTOR_ADDRESSES_SIZE);
+        ushort nmi_data = 0x80BC;
+        ushort reset_data = 0x8000;
+        ushort irq_data = 0x8202;
+        writer.Write(new ushort[] { nmi_data, reset_data, irq_data });
 
         // Use CHR_ROM from hello.nes
         writer.Write(data, (int)writer.Length, NESWriter.CHR_ROM_BLOCK_SIZE);


### PR DESCRIPTION
These bytes are addresses that the 6502 will look for during interrupt/reset cycles.

This will get rid of the todo and describe in code what the bytes are for 😄 

Note that this will still be somewhat specific to the ROM we are creating in-project, however it should work for a lot of common NES titles ("mapper 0" games), I think. We would have to research a bit more in depth of NES mappers and come up with a more general solution in order to "full support" .NES projects.