### PR TITLE
[tests] use Roslyn for writing nicer tests

### DIFF
--- a/src/dotnes.tests/IL2NESWriterTests.cs
+++ b/src/dotnes.tests/IL2NESWriterTests.cs
@@ -93,7 +93,7 @@ public class IL2NESWriterTests
     [Fact]
     public void Write_Main_hello()
     {
-        const ushort sizeOfMain = 0x43;
+        const ushort sizeOfMain = 0x4B;
         using var writer = GetWriter();
 
         // pal_col(0, 0x02);
@@ -133,7 +133,7 @@ public class IL2NESWriterTests
         // while (true) ;
         writer.Write(ILOpCode.Br_s, 254, sizeOfMain);
 
-        var expected = Utilities.ToByteArray("A900 20A285 A902 203E82 A901 20A285 A914 203E82 A902 20A285 A920 203E82 A903 20A285 A930 203E82 A220 A942 20D483 A9F1 A285 20B885 A200 A90C 204F83 208982 4C4085");
+        var expected = Utilities.ToByteArray("A900 20AA85 A902 203E82 A901 20AA85 A914 203E82 A902 20AA85 A920 203E82 A903 20AA85 A930 203E82 A220 A942 20D483 A9F1 A285 20C085 A200 A90C 204F83 208982 4C4885");
         AssertEx.Equal(expected, writer);
     }
 

--- a/src/dotnes.tests/IL2NESWriterTests.cs
+++ b/src/dotnes.tests/IL2NESWriterTests.cs
@@ -93,7 +93,7 @@ public class IL2NESWriterTests
     [Fact]
     public void Write_Main_hello()
     {
-        const ushort sizeOfMain = 0x4B;
+        const ushort sizeOfMain = 0x43;
         using var writer = GetWriter();
 
         // pal_col(0, 0x02);
@@ -136,19 +136,19 @@ public class IL2NESWriterTests
         var expected = Utilities.ToByteArray(
             """
             A900    ; LDA #$00
-            20AA85  ; JSR pusha
+            20A285  ; JSR pusha
             A902    ; LDA #$02
             203E82  ; JSR pal_col
             A901    ; LDA #$01
-            20AA85  ; JSR pusha
+            20A285  ; JSR pusha
             A914    ; LDA #$14
             203E82  ; JSR pal_col
             A902    ; LDA #$02
-            20AA85  ; JSR pusha
+            20A285  ; JSR pusha
             A920    ; LDA #$20
             203E82  ; JSR pal_col
             A903    ; LDA #$03
-            20AA85  ; JSR pusha
+            20A285  ; JSR pusha
             A930    ; LDA #$30
             203E82  ; JSR pal_col
             A220    ; LDX #$20
@@ -156,12 +156,12 @@ public class IL2NESWriterTests
             20D483  ; JSR vram_adr
             A9F1    ; LDA #$F1
             A285    ; LDX #$85
-            20C085  ; JSR pushax
+            20B885  ; JSR pushax
             A200    ; LDX #$00
             A90C    ; LDA #$0C
             204F83  ; JSR vram_write
             208982  ; JSR ppu_on_all
-            4C4885  ; JMP $8548
+            4C4085  ; JMP $8548
             """);
         AssertEx.Equal(expected, writer);
     }

--- a/src/dotnes.tests/IL2NESWriterTests.cs
+++ b/src/dotnes.tests/IL2NESWriterTests.cs
@@ -133,36 +133,7 @@ public class IL2NESWriterTests
         // while (true) ;
         writer.Write(ILOpCode.Br_s, 254, sizeOfMain);
 
-        var expected = Utilities.ToByteArray(
-            """
-            A900    ; LDA #$00
-            20A285  ; JSR pusha
-            A902    ; LDA #$02
-            203E82  ; JSR pal_col
-            A901    ; LDA #$01
-            20A285  ; JSR pusha
-            A914    ; LDA #$14
-            203E82  ; JSR pal_col
-            A902    ; LDA #$02
-            20A285  ; JSR pusha
-            A920    ; LDA #$20
-            203E82  ; JSR pal_col
-            A903    ; LDA #$03
-            20A285  ; JSR pusha
-            A930    ; LDA #$30
-            203E82  ; JSR pal_col
-            A220    ; LDX #$20
-            A942    ; LDA #$42
-            20D483  ; JSR vram_adr
-            A9F1    ; LDA #$F1
-            A285    ; LDX #$85
-            20B885  ; JSR pushax
-            A200    ; LDX #$00
-            A90C    ; LDA #$0C
-            204F83  ; JSR vram_write
-            208982  ; JSR ppu_on_all
-            4C4085  ; JMP $8548
-            """);
+        var expected = Utilities.ToByteArray("A900 20A285 A902 203E82 A901 20A285 A914 203E82 A902 20A285 A920 203E82 A903 20A285 A930 203E82 A220 A942 20D483 A9F1 A285 20B885 A200 A90C 204F83 208982 4C4085");
         AssertEx.Equal(expected, writer);
     }
 

--- a/src/dotnes.tests/IL2NESWriterTests.cs
+++ b/src/dotnes.tests/IL2NESWriterTests.cs
@@ -133,7 +133,36 @@ public class IL2NESWriterTests
         // while (true) ;
         writer.Write(ILOpCode.Br_s, 254, sizeOfMain);
 
-        var expected = Utilities.ToByteArray("A900 20AA85 A902 203E82 A901 20AA85 A914 203E82 A902 20AA85 A920 203E82 A903 20AA85 A930 203E82 A220 A942 20D483 A9F1 A285 20C085 A200 A90C 204F83 208982 4C4885");
+        var expected = Utilities.ToByteArray(
+            """
+            A900    ; LDA #$00
+            20AA85  ; JSR pusha
+            A902    ; LDA #$02
+            203E82  ; JSR pal_col
+            A901    ; LDA #$01
+            20AA85  ; JSR pusha
+            A914    ; LDA #$14
+            203E82  ; JSR pal_col
+            A902    ; LDA #$02
+            20AA85  ; JSR pusha
+            A920    ; LDA #$20
+            203E82  ; JSR pal_col
+            A903    ; LDA #$03
+            20AA85  ; JSR pusha
+            A930    ; LDA #$30
+            203E82  ; JSR pal_col
+            A220    ; LDX #$20
+            A942    ; LDA #$42
+            20D483  ; JSR vram_adr
+            A9F1    ; LDA #$F1
+            A285    ; LDX #$85
+            20C085  ; JSR pushax
+            A200    ; LDX #$00
+            A90C    ; LDA #$0C
+            204F83  ; JSR vram_write
+            208982  ; JSR ppu_on_all
+            4C4885  ; JMP $8548
+            """);
         AssertEx.Equal(expected, writer);
     }
 

--- a/src/dotnes.tests/NESWriterTests.cs
+++ b/src/dotnes.tests/NESWriterTests.cs
@@ -5,7 +5,7 @@ namespace dotnes.tests;
 public class NESWriterTests
 {
     const ushort SizeOfMain = 67;
-    readonly MemoryStream _stream = new MemoryStream();
+    readonly MemoryStream _stream = new();
     readonly ILogger _logger;
 
     public NESWriterTests(ITestOutputHelper output)

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -1,0 +1,144 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit.Abstractions;
+
+namespace dotnes.tests;
+
+public class RoslynTests
+{
+    readonly MemoryStream _stream = new();
+    readonly ILogger _logger;
+
+    public RoslynTests(ITestOutputHelper output) => _logger = new XUnitLogger(output);
+
+    void AssertProgram(string csharpSource, string expectedAssembly)
+    {
+        _stream.SetLength(0);
+
+        // Implicit global using
+        csharpSource = $"using static NES.NESLib;{Environment.NewLine}{csharpSource}";
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource);
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(NESLib).Assembly.Location)
+        };
+
+        var compilation = CSharpCompilation
+            .Create(
+                "hello.dll",
+                [syntaxTree],
+                references: references,
+                options: new CSharpCompilationOptions(OutputKind.ConsoleApplication,
+                    optimizationLevel: OptimizationLevel.Debug,
+                    deterministic: true));
+
+        var emitResults = compilation.Emit(_stream);
+        if (!emitResults.Success)
+        {
+            Assert.Fail(string.Join(Environment.NewLine, emitResults.Diagnostics.Select(d => d.GetMessage())));
+        }
+
+        _stream.Seek(0, SeekOrigin.Begin);
+
+        using var il = new RoslynTranspiler(_stream, _logger);
+        il.Write(new MemoryStream());
+        AssertEx.Equal(Utilities.ToByteArray(expectedAssembly), il.ToArray());
+    }
+
+    /// <summary>
+    /// Class for overriding SecondPass()
+    /// </summary>
+    class RoslynTranspiler : Transpiler
+    {
+        readonly MemoryStream _stream = new();
+        readonly IL2NESWriter _writer;
+
+        public RoslynTranspiler(Stream stream, ILogger logger)
+            : base(stream, [new AssemblyReader(new StreamReader(Utilities.GetResource("chr_generic.s")))])
+        {
+            _writer = new(_stream, leaveOpen: true, logger);
+        }
+
+        protected override void SecondPass(ushort sizeOfMain, IL2NESWriter _)
+        {
+            // Still call base if we ever want to check binary at the end
+            base.SecondPass(sizeOfMain, _);
+
+            foreach (var instruction in ReadStaticVoidMain())
+            {
+                if (instruction.Integer != null)
+                {
+                    _writer.Write(instruction.OpCode, instruction.Integer.Value, sizeOfMain);
+                }
+                else if (instruction.String != null)
+                {
+                    _writer.Write(instruction.OpCode, instruction.String, sizeOfMain);
+                }
+                else if (instruction.Bytes != null)
+                {
+                    _writer.Write(instruction.OpCode, instruction.Bytes.Value, sizeOfMain);
+                }
+                else
+                {
+                    _writer.Write(instruction.OpCode, sizeOfMain);
+                }
+            }
+
+            _writer.Flush();
+        }
+
+        public byte[] ToArray() => _stream.ToArray();
+    }
+
+    [Fact]
+    public void HelloWorld()
+    {
+        AssertProgram(
+            csharpSource:
+                """
+                pal_col(0, 0x02);
+                pal_col(1, 0x14);
+                pal_col(2, 0x20);
+                pal_col(3, 0x30);
+                vram_adr(NTADR_A(2, 2));
+                vram_write("HELLO, .NET!");
+                ppu_on_all();
+                while (true) ;
+                """,
+            expectedAssembly:
+                """
+                A900    ; LDA #$00
+                20AA85  ; JSR pusha
+                A902    ; LDA #$02
+                203E82  ; JSR pal_col
+                A901    ; LDA #$01
+                20AA85  ; JSR pusha
+                A914    ; LDA #$14
+                203E82  ; JSR pal_col
+                A902    ; LDA #$02
+                20AA85  ; JSR pusha
+                A920    ; LDA #$20
+                203E82  ; JSR pal_col
+                A903    ; LDA #$03
+                20AA85  ; JSR pusha
+                A930    ; LDA #$30
+                203E82  ; JSR pal_col
+                A220    ; LDX #$20
+                A942    ; LDA #$42
+                20D483  ; JSR vram_adr
+                A9F1    ; LDA #$F1
+                A285    ; LDX #$85
+                20C085  ; JSR pushax
+                A200    ; LDX #$00
+                A90C    ; LDA #$0C
+                204F83  ; JSR vram_write
+                2089A9  ; JSR ppu_on_all
+                018D    ; ???
+                2403A9  ; ???
+                22A286  ; ???
+                4C4885  ; JMP $8548
+                """);
+    }
+}

--- a/src/dotnes.tests/Utilities.cs
+++ b/src/dotnes.tests/Utilities.cs
@@ -1,4 +1,6 @@
-﻿namespace dotnes.tests;
+﻿using System.Text;
+
+namespace dotnes.tests;
 
 class Utilities
 {
@@ -13,8 +15,24 @@ class Utilities
     public static byte[] ToByteArray(string text)
     {
         ArgumentNullException.ThrowIfNull(text);
-        text = text.Replace(" ", "").Replace("\n", "").Replace("\r", "").Replace("\t", "");
 
+        var builder = new StringBuilder();
+        using var reader = new StringReader(text);
+        while (reader.Peek() != -1)
+        {
+            var line = reader.ReadLine();
+            if (line == null)
+                break;
+
+            int comment = line.IndexOf(';');
+            if (comment != -1)
+            {
+                line = line[..comment];
+            }
+            builder.Append(line.Replace(" ", "").Replace("\n", "").Replace("\r", "").Replace("\t", ""));
+        }
+
+        text = builder.ToString();
         int length = text.Length >> 1;
         var bytes = new byte[length];
         for (int i = 0; i < length; i++)

--- a/src/dotnes.tests/dotnes.tests.csproj
+++ b/src/dotnes.tests/dotnes.tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Using Include="NES" />
     <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Verify.Xunit" Version="26.4.5" />
     <PackageReference Include="xunit" Version="2.9.0" />


### PR DESCRIPTION
This should allow us to write short C# programs as a string, and then assert the generated 6502 assembly code at the end.

I think this will make it a lot easier to test more programs with a quicker turnaround time & debug cycle.