### PR TITLE
[msbuild] `Transpile` target should run if `@(NESAssembly)` files change

### DIFF
--- a/src/dotnes.tasks/Targets/dotnes.targets
+++ b/src/dotnes.tasks/Targets/dotnes.targets
@@ -5,7 +5,7 @@
     <IncrementalCleanDependsOn>$(IncrementalCleanDependsOn);Transpile</IncrementalCleanDependsOn>
   </PropertyGroup>
   <Target Name="Transpile" AfterTargets="Build"
-      Inputs="$(TargetPath)" Outputs="$(NESTargetPath)">
+      Inputs="$(TargetPath);@(NESAssembly)" Outputs="$(NESTargetPath)">
     <TranspileToNES
         TargetPath="$(TargetPath)"
         AssemblyFiles="@(NESAssembly)"


### PR DESCRIPTION
There was previously an incremental build bug:

1. `dotnet run`

2. Modify `chr_generic.s`

3. `dotnet run`

Your changes aren't there! You would need to run `dotnet clean` or `dotnet build` to fix it.