### PR TITLE
Remove [DllImport("ext")] requirement for extern methods

### DIFF
--- a/docs/8bitworkshop-samples.md
+++ b/docs/8bitworkshop-samples.md
@@ -146,10 +146,10 @@
 - **Description:** Demonstrates the FamiTone2 library for music and sound effects, with controller-triggered SFX.
 - **Status:** ✅ Implemented
 - **dotnes sample:** `fami`
-- **Features:** Full ca65-compatible assembler (`Ca65Assembler`), extern `.s` file linking via `[DllImport("ext")]`, FamiTone2 music/SFX driver, `nmi_set_callback`, `famitone_init`, `sfx_init`, `music_play`, `sfx_play`, controller-triggered sound effects.
+- **Features:** Full ca65-compatible assembler (`Ca65Assembler`), extern `.s` file linking via `static extern`, FamiTone2 music/SFX driver, `nmi_set_callback`, `famitone_init`, `sfx_init`, `music_play`, `sfx_play`, controller-triggered sound effects.
 - **New Features Added:**
   - ca65 assembler with conditional assembly, expression evaluation (&&, ||, !), all 6502 addressing modes
-  - Extern assembly linking (`[DllImport("ext")] static extern void func()` → `JSR _func`)
+  - Extern assembly linking (`static extern void func()` → `JSR _func`)
   - `famitone_init(string)`, `sfx_init(string)`, `nmi_set_callback(string)` NESLib stubs
   - `music_play(byte)`, `music_stop()`, `sfx_play(byte, byte)` via extern declarations
   - Block relocations and internal labels for music data cross-references
@@ -235,7 +235,7 @@
 - **Status:** ✅ Already Implemented
 - **dotnes sample:** `climber`
 - **Note:** Uses SoA (structure-of-arrays) instead of structs with bitfields. All game state is local to avoid Roslyn display class closures. Static helper functions for pure computations.
-- **Features used:** `vrambuf_put`, `vrambuf_flush`, `Array.Fill`, `pad_poll`, `oam_meta_spr_pal`, `oam_spr`, `oam_hide_rest`, `rand8`, `bcd_add`, `pal_bright`, `scroll`, `delay`, modulo `%`, bit shifts `>>` `<<`, 16-bit arithmetic (multiply, add, shift), runtime-vs-runtime comparison, long-form branches, branch relaxation, FamiTone2 music/SFX via `DllImport`
+- **Features used:** `vrambuf_put`, `vrambuf_flush`, `Array.Fill`, `pad_poll`, `oam_meta_spr_pal`, `oam_spr`, `oam_hide_rest`, `rand8`, `bcd_add`, `pal_bright`, `scroll`, `delay`, modulo `%`, bit shifts `>>` `<<`, 16-bit arithmetic (multiply, add, shift), runtime-vs-runtime comparison, long-form branches, branch relaxation, FamiTone2 music/SFX via `static extern`
 
 ### transtable.c
 - **Description:** Custom CHR tileset loaded into CHR RAM with `#pragma charmap` translation tables for text display.
@@ -344,7 +344,7 @@
 | Arrays of structs — `newarr` struct, `ldelema`, `stfld`/`ldfld` with AbsoluteX | climber, shoot2, siegegame |
 | `Array.Fill` / `Array.Copy` — inline 6502 fill/copy loops | climber, siegegame |
 | ca65 assembler — full expression evaluator (&&, \|\|, !), conditional assembly, all addressing modes | fami (FamiTone2 linking) |
-| Extern assembly linking — `[DllImport("ext")]` → `JSR _func`, `.s` files assembled and linked | fami (FamiTone2, music data, SFX data) |
+| Extern assembly linking — `static extern` → `JSR _func`, `.s` files assembled and linked | fami (FamiTone2, music data, SFX data) |
 | `famitone_init` / `sfx_init` / `nmi_set_callback` / `music_play` / `sfx_play` | fami, climber (music and SFX) |
 
 ### Roadmap to climber.c
@@ -358,7 +358,7 @@ Prioritized TODO list of features needed to port climber.c, ordered by dependenc
 - [x] **sbyte (signed char)** — `Ldc_i4_m1`, negative constants via two's complement, `conv.i1`/`conv.i2`/`conv.i4` as no-ops on 8-bit 6502. Signed comparisons work via `Blt_s` (BMI).
 - [x] **Arrays of structs** — `newarr` for struct types allocates `count * structSize` bytes. `ldelema` computes element address (constant index: compile-time; variable index: multiply+TAX). Handles Roslyn's optimized `dup` pattern where array ref stays on the evaluation stack. `stfld`/`ldfld` work with both absolute and AbsoluteX addressing for array elements.
 - [x] **memset/memcpy** — `System.Array.Fill<T>` → inline 6502 fill loop (`LDA #val; LDX #size-1; STA arr,X; DEX; BPL`). `System.Array.Copy` → inline copy loop (`LDX #0; LDA src,X; STA dst,X; INX; CPX #len; BNE`). BCL method names are type-qualified (e.g., `Array.Fill`) to avoid collisions with user functions. Handles Roslyn's eval-stack pattern (newarr+dup) where arrays are never stored to locals.
-- [x] **FamiTone2 integration** — Full ca65-compatible assembler (`Ca65Assembler.cs`) supporting all 6502 instructions, conditional assembly, expression evaluation, label aliases. `famitone_init(string)`, `sfx_init(string)`, `nmi_set_callback(string)` NESLib stubs emit label address loads + JSR. Extern methods via `[DllImport("ext")]` emit JSR with `_` prefix convention. FamiTone2 `.s` files assembled and linked into ROM. See `samples/fami/`.
+- [x] **FamiTone2 integration** — Full ca65-compatible assembler (`Ca65Assembler.cs`) supporting all 6502 instructions, conditional assembly, expression evaluation, label aliases. `famitone_init(string)`, `sfx_init(string)`, `nmi_set_callback(string)` NESLib stubs emit label address loads + JSR. Extern methods via `static extern` emit JSR with `_` prefix convention. FamiTone2 `.s` files assembled and linked into ROM. See `samples/fami/`.
 - [x] **Bit shifts (Shr/Shl)** — `>>` emits LSR A (logical shift right), `<<` emits ASL A (arithmetic shift left). Supports runtime values and constant shift counts. Used for extracting hi/lo bytes of ushort values.
 - [x] **Runtime-vs-runtime comparisons** — `EmitBranchCompare` detects LDA Absolute (runtime) vs LDA Immediate (constant) and emits `CMP $addr` or `CMP #imm` accordingly. Enables `for (i = 0; i < limit; i++)` where `limit` is a variable.
 - [x] **Long-form branches** — All branch opcodes (Blt, Ble, Bge, Bgt, Bne_un, Beq) support both short (2-byte) and long (5-byte) IL forms. Long forms use inverted-condition + JMP trampolines to handle large code offsets.

--- a/samples/climber/Program.cs
+++ b/samples/climber/Program.cs
@@ -4,12 +4,10 @@
 
 #pragma warning disable CS0649, CS8321, CS0219
 
-using System.Runtime.InteropServices;
-
-// Link FamiTone2 functions
-[DllImport("ext")] static extern void music_play(byte song);
-[DllImport("ext")] static extern void music_stop();
-[DllImport("ext")] static extern void sfx_play(byte sound, byte channel);
+// Link FamiTone2 functions (from famitone2.s / sounds.s)
+static extern void music_play(byte song);
+static extern void music_stop();
+static extern void sfx_play(byte sound, byte channel);
 
 // Constants
 const byte COLS = 30;

--- a/samples/fami/Program.cs
+++ b/samples/fami/Program.cs
@@ -1,11 +1,9 @@
 // fami.c port — Demonstrates FamiTone2 library for music and sound effects
 // Press controller buttons to hear sound effects.
 
-using System.Runtime.InteropServices;
-
-// Link FamiTone2 functions (from famitone2.s)
-[DllImport("ext")] static extern void music_play(byte song);
-[DllImport("ext")] static extern void sfx_play(byte sound, byte channel);
+// Link FamiTone2 functions (from famitone2.s / sounds.s)
+static extern void music_play(byte song);
+static extern void sfx_play(byte sound, byte channel);
 
 pal_col(1, 0x04);
 pal_col(2, 0x20);

--- a/src/dotnes.tasks/Targets/dotnes.props
+++ b/src/dotnes.tasks/Targets/dotnes.props
@@ -15,6 +15,8 @@
     <Optimize>true</Optimize>
     <!-- Also removes extra IL -->
     <DebugSymbols>false</DebugSymbols>
+    <!-- Allow 'static extern' without [DllImport] -->
+    <NoWarn>$(NoWarn);CS0626</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <NESAssembly Include="*.s" />

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -1280,8 +1280,7 @@ public class RoslynTests
             var assemblyFiles = new List<AssemblyReader> { reader };
             var bytes = GetProgramBytes(
                 """
-                using System.Runtime.InteropServices;
-                [DllImport("ext")] static extern void my_extern_func();
+                static extern void my_extern_func();
                 my_extern_func();
                 ppu_on_all();
                 while (true) ;
@@ -1322,8 +1321,7 @@ public class RoslynTests
             var assemblyFiles = new List<AssemblyReader> { reader };
             var bytes = GetProgramBytes(
                 """
-                using System.Runtime.InteropServices;
-                [DllImport("ext")] static extern void set_value(byte val);
+                static extern void set_value(byte val);
                 set_value(42);
                 ppu_on_all();
                 while (true) ;


### PR DESCRIPTION
The transpiler already detects extern methods via `RelativeVirtualAddress == 0`, making the `[DllImport("ext")]` attribute unnecessary boilerplate. The `"ext"` string was never read by the transpiler.

## Before
```csharp
using System.Runtime.InteropServices;

[DllImport("ext")] static extern void music_play(byte song);
```

## After
```csharp
static extern void music_play(byte song);
```

## Changes
- Suppress CS0626 in `dotnes.props` (allows `static extern` without `[DllImport]`)
- Remove `[DllImport("ext")]` from climber and fami samples
- Remove `using System.Runtime.InteropServices` from samples
- Update RoslynTests to use plain `static extern` declarations
- Update docs to reflect the simpler syntax

All 305 tests pass.