### PR TITLE
Fix pr-iterate skill: use --body-file for review formatting

### DIFF
--- a/.github/skills/pr-iterate/SKILL.md
+++ b/.github/skills/pr-iterate/SKILL.md
@@ -22,8 +22,8 @@ and ready for human review. The human will review and merge — never merge your
 **Every** comment, review body, or PR description edit you post must start with
 the 🤖 emoji so humans can instantly tell it came from automation. This applies to:
 
-- PR review bodies (`gh pr review --body "🤖 ..."`)
-- PR comments (`gh pr comment --body "🤖 ..."`)
+- PR review bodies (`gh pr review --body-file ...` — always use `--body-file`, see Step 3)
+- PR comments (`gh pr comment --body-file ...`)
 - Commit messages do NOT need the emoji (they already have the Co-authored-by trailer)
 
 ## Workflow
@@ -70,12 +70,17 @@ Submit a review on the PR. Always prefix the body with 🤖.
 avoid shell escaping issues with backticks and special characters:
 
 ```powershell
-$body = @"
+$body = @'
 🤖 Your review here. Use `backticks` freely — no escaping needed.
-"@
-$body | Set-Content -Path review.md -Encoding utf8
-gh pr review <number> --repo <owner>/<repo> --approve --body-file review.md
-Remove-Item review.md
+'@
+$tempFile = New-TemporaryFile
+try {
+    $body | Set-Content -Path $tempFile.FullName -Encoding utf8
+    gh pr review <number> --repo <owner>/<repo> --approve --body-file $tempFile.FullName
+}
+finally {
+    Remove-Item $tempFile -ErrorAction SilentlyContinue
+}
 ```
 
 **Never** pass review bodies with backticks directly via `--body` — PowerShell and


### PR DESCRIPTION
The pr-iterate skill was using `gh pr review --body "..."` which mangles backticks into backslash-escaped garbage in PowerShell. Updated to use `--body-file` with a temp file instead.
