### PR TITLE
Fix ANESE cache: touch restored files to prevent re-download

### DIFF
--- a/.github/workflows/cache-anese/action.yml
+++ b/.github/workflows/cache-anese/action.yml
@@ -17,4 +17,6 @@ runs:
       # Touch cached zip/stamp files so MSBuild sees them as newer than the csproj.
       # Without this, git checkout gives the csproj a fresh timestamp that defeats
       # MSBuild's Inputs/Outputs incremental check, causing re-downloads every build.
-      find src/dotnes.anese/obj -name '*.zip' -o -name 'LICENSE' -o -name '*.stamp' 2>/dev/null | xargs -r touch
+      if [ -d src/dotnes.anese/obj ]; then
+        find src/dotnes.anese/obj \( -name '*.zip' -o -name 'LICENSE' -o -name '*.stamp' \) -exec touch {} +
+      fi


### PR DESCRIPTION
The `actions/cache` step restores zip files into `obj/Debug` and `obj/Release`, but MSBuild's `_Download` target uses `Inputs/Outputs` incremental checking:

```xml
<Target Name="_Download" Inputs="$(MSBuildThisFile)" Outputs="@(_Downloads)">
```

Since `git checkout` gives the csproj a fresh timestamp, it's always newer than the cached zip files, so MSBuild re-downloads every build despite the cache hit.

**Fix:** Touch all cached `.zip`, `LICENSE`, and `.stamp` files after cache restore so they appear newer than the csproj to MSBuild.

**Verified via binlog analysis:** Before this fix, `_Download` shows `Building target "_Download" completely` on every CI run. After this fix, MSBuild should see the cached outputs as up-to-date and skip both `_Download` and `_Unzip`.
