### PR TITLE
CI: ignore build-server shutdown errors

### DIFF
--- a/.github/workflows/dotnes.yml
+++ b/.github/workflows/dotnes.yml
@@ -29,9 +29,10 @@ jobs:
         dotnet new nes --output samples/foo && \
         dotnet build samples/foo/foo.csproj -bl:foo-debug.binlog && \
         dotnet build samples/foo/foo.csproj -c Release -bl:foo-release.binlog
-    - name: shutdown
+    - name: shutdown (best effort)
+      if: always()
       run: dotnet build-server shutdown
-      continue-on-error: true
+      continue-on-error: true # best-effort cleanup; failures intentionally ignored
     - name: upload logs
       if: always()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `dotnet build-server shutdown` step can fail with "VB/C# compiler server failed to shut down" errors, causing spurious CI failures. Since this is just cleanup (not a build/test step), `continue-on-error: true` lets CI pass even if the compiler server doesn't shut down cleanly.

Example failure: https://github.com/jonathanpeppers/dotnes/actions/runs/23101766463/job/67103619406?pr=219
