### PR TITLE
Change pad_trigger/pad_state return type to PAD and clean up samples

### DIFF
--- a/samples/battery/Program.cs
+++ b/samples/battery/Program.cs
@@ -29,14 +29,14 @@ ppu_on_all();
 while (true)
 {
     ppu_wait_frame();
-    byte pad = pad_trigger(0);
-    if ((pad & (byte)PAD.A) != 0)
+    PAD pad = pad_trigger(0);
+    if ((pad & PAD.A) != 0)
     {
         count++;
         poke(SRAM_START, count);
         display_count(count);
     }
-    if ((pad & (byte)PAD.B) != 0)
+    if ((pad & PAD.B) != 0)
     {
         count = 0;
         poke(SRAM_START, count);

--- a/samples/metatrigger/Program.cs
+++ b/samples/metatrigger/Program.cs
@@ -72,25 +72,25 @@ while (true)
     byte oam_id = 0;
 
     // pad_trigger detects newly pressed buttons (edge detection)
-    byte trig = pad_trigger(0);
-    if ((trig & (byte)PAD.LEFT) != 0)
+    PAD trig = pad_trigger(0);
+    if ((trig & PAD.LEFT) != 0)
         actor_dx[0] = 254;
-    else if ((trig & (byte)PAD.RIGHT) != 0)
+    else if ((trig & PAD.RIGHT) != 0)
         actor_dx[0] = 2;
     else
         actor_dx[0] = 0;
 
     // A/B buttons change brightness (trigger = one press per tap)
-    if ((trig & (byte)PAD.A) != 0)
+    if ((trig & PAD.A) != 0)
         vbright = (byte)(vbright - 1);
-    if ((trig & (byte)PAD.B) != 0)
+    if ((trig & PAD.B) != 0)
         vbright = (byte)(vbright + 1);
 
     // pad_state reads currently held buttons (continuous)
-    byte state = pad_state(0);
-    if ((state & (byte)PAD.UP) != 0)
+    PAD state = pad_state(0);
+    if ((state & PAD.UP) != 0)
         actor_dy[0] = 254;
-    else if ((state & (byte)PAD.DOWN) != 0)
+    else if ((state & PAD.DOWN) != 0)
         actor_dy[0] = 2;
     else
         actor_dy[0] = 0;

--- a/samples/procgen/Program.cs
+++ b/samples/procgen/Program.cs
@@ -26,8 +26,8 @@ ppu_on_all();
 while (true)
 {
     ppu_wait_nmi();
-    byte trigger = pad_trigger(0);
-    if ((trigger & (byte)PAD.START) != 0)
+    PAD trigger = pad_trigger(0);
+    if ((trigger & PAD.START) != 0)
     {
         seed = (byte)(seed + 1);
         set_rand(seed);

--- a/samples/scoreboard/Program.cs
+++ b/samples/scoreboard/Program.cs
@@ -33,8 +33,8 @@ byte[] digits = new byte[4];
 
 while (true)
 {
-    byte trig = pad_trigger(0);
-    if ((trig & (byte)PAD.A) != 0)
+    PAD trig = pad_trigger(0);
+    if ((trig & PAD.A) != 0)
     {
         d3 = (byte)(d3 + 1);
         if (d3 == 0x3A) { d3 = 0x30; d2 = (byte)(d2 + 1); }

--- a/samples/siegegame/Program.cs
+++ b/samples/siegegame/Program.cs
@@ -51,7 +51,7 @@ byte lives = 3;
 byte frameCount = 0;
 byte spawnTimer = 0;
 byte spawnRate = 60;
-byte lastTrigger = 0;
+PAD lastTrigger = 0;
 byte castleHits = 0;
 byte activeCount = 0;
 
@@ -189,7 +189,7 @@ while (true)
         {
             ppu_wait_nmi();
             lastTrigger = pad_trigger(0);
-            if ((byte)(lastTrigger & (byte)PAD.A) != 0)
+            if ((lastTrigger & PAD.A) != 0)
             {
                 score = 0;
                 wave = 1;
@@ -240,22 +240,22 @@ while (true)
             lastTrigger = pad_trigger(0);
 
             // Cursor movement
-            if ((byte)(lastTrigger & (byte)PAD.LEFT) != 0)
+            if ((lastTrigger & PAD.LEFT) != 0)
             {
                 if (cursorX > (byte)(BOARD_X + 1))
                     cursorX = (byte)(cursorX - 1);
             }
-            if ((byte)(lastTrigger & (byte)PAD.RIGHT) != 0)
+            if ((lastTrigger & PAD.RIGHT) != 0)
             {
                 if (cursorX < (byte)(BOARD_X + BOARD_W - 1))
                     cursorX = (byte)(cursorX + 1);
             }
-            if ((byte)(lastTrigger & (byte)PAD.UP) != 0)
+            if ((lastTrigger & PAD.UP) != 0)
             {
                 if (cursorY > BOARD_Y)
                     cursorY = (byte)(cursorY - 1);
             }
-            if ((byte)(lastTrigger & (byte)PAD.DOWN) != 0)
+            if ((lastTrigger & PAD.DOWN) != 0)
             {
                 if (cursorY < (byte)(BOARD_Y + BOARD_H - 1))
                     cursorY = (byte)(cursorY + 1);
@@ -263,7 +263,7 @@ while (true)
 
             // Place wall with A — check arrays, defer VRAM update
             doPlaceWall = 0;
-            if ((byte)(lastTrigger & (byte)PAD.A) != 0)
+            if ((lastTrigger & PAD.A) != 0)
             {
                 if (cursorX > BOARD_X)
                 {
@@ -300,7 +300,7 @@ while (true)
 
             // Remove wall with B — check arrays, defer VRAM update
             doRemoveWall = 0;
-            if ((byte)(lastTrigger & (byte)PAD.B) != 0)
+            if ((lastTrigger & PAD.B) != 0)
             {
                 for (byte w = 0; w < wallCount; w++)
                 {
@@ -448,7 +448,7 @@ while (true)
         {
             ppu_wait_nmi();
             lastTrigger = pad_trigger(0);
-            if ((byte)(lastTrigger & (byte)PAD.A) != 0)
+            if ((lastTrigger & PAD.A) != 0)
             {
                 clear_screen();
                 gameState = STATE_TITLE;

--- a/samples/snake/Program.cs
+++ b/samples/snake/Program.cs
@@ -47,7 +47,7 @@ byte s2 = 0x30;
 byte[] sbuf = new byte[3];
 
 // temp globals (needed to work around transpiler array limitations)
-byte trig = 0;
+PAD trig = 0;
 byte headX = 0;
 byte headY = 0;
 byte tmpX = 0;
@@ -85,19 +85,19 @@ while (true)
     {
         // read direction input (use global to avoid AND cascade bug)
         trig = pad_trigger(0);
-        if ((byte)(trig & (byte)PAD.RIGHT) != 0)
+        if ((trig & PAD.RIGHT) != 0)
         {
             if (dir != DIR_LEFT) dir = DIR_RIGHT;
         }
-        if ((byte)(trig & (byte)PAD.LEFT) != 0)
+        if ((trig & PAD.LEFT) != 0)
         {
             if (dir != DIR_RIGHT) dir = DIR_LEFT;
         }
-        if ((byte)(trig & (byte)PAD.UP) != 0)
+        if ((trig & PAD.UP) != 0)
         {
             if (dir != DIR_DOWN) dir = DIR_UP;
         }
-        if ((byte)(trig & (byte)PAD.DOWN) != 0)
+        if ((trig & PAD.DOWN) != 0)
         {
             if (dir != DIR_UP) dir = DIR_DOWN;
         }

--- a/src/neslib/NESLib.cs
+++ b/src/neslib/NESLib.cs
@@ -148,12 +148,12 @@ public static class NESLib
     /// <summary>
     /// get pad trigger
     /// </summary>
-    public static byte pad_trigger(byte pad) => throw null!;
+    public static PAD pad_trigger(byte pad) => throw null!;
 
     /// <summary>
     /// get pad state
     /// </summary>
-    public static byte pad_state(byte pad) => throw null!;
+    public static PAD pad_state(byte pad) => throw null!;
 
     /// <summary>
     /// read from vram

--- a/src/neslib/PublicAPI.Unshipped.txt
+++ b/src/neslib/PublicAPI.Unshipped.txt
@@ -75,8 +75,8 @@ static NES.NESLib.oam_clear_fast() -> void
 static NES.NESLib.oam_meta_spr_clip(int x, byte y, byte[]! metasprite) -> void
 static NES.NESLib.oam_meta_spr_pal(byte x, byte y, byte pal, byte[]! data) -> void
 static NES.NESLib.oam_off -> byte
-static NES.NESLib.pad_state(byte pad) -> byte
-static NES.NESLib.pad_trigger(byte pad) -> byte
+static NES.NESLib.pad_state(byte pad) -> NES.PAD
+static NES.NESLib.pad_trigger(byte pad) -> NES.PAD
 static NES.NESLib.peek(ushort addr) -> byte
 static NES.NESLib.play_music() -> void
 static NES.NESLib.poke(ushort addr, byte value) -> void


### PR DESCRIPTION
`pad_trigger()` and `pad_state()` returned `byte` while `pad_poll()` already returned `PAD`. Since `PAD` is `enum PAD : byte`, these should be consistent. This is a follow-up to PR #227 which fixed transpiler support for `PAD` enum local variables.

### Changes

- **NESLib.cs**: `pad_trigger` and `pad_state` now return `PAD` (matching `pad_poll`)
- **PublicAPI.Unshipped.txt**: Updated signatures
- **6 samples cleaned up** (removed 24 `(byte)PAD.X` casts):
  - battery, procgen, scoreboard, metatrigger, snake, siegegame

### Before / After

```csharp
// Before
byte trig = pad_trigger(0);
if ((trig & (byte)PAD.A) != 0) { ... }

// After
PAD trig = pad_trigger(0);
if ((trig & PAD.A) != 0) { ... }
```

The 2 remaining `(byte)PAD.X` casts in `climber` are correct -- they compare against `rand8()` output, not a PAD variable.

All 498 tests pass.