### PR TITLE
Fix climber: mines appear on lower floors with XOR'd PRNG

### DIFF
--- a/samples/climber/Program.cs
+++ b/samples/climber/Program.cs
@@ -39,11 +39,14 @@ const byte JUMPING = 4;
 const byte FALLING = 5;
 const byte PACING = 6;
 
-// Pure utility function (no captured state)
+// Random byte between (a ... b-1)
+// XOR two rand8() calls to break the 255-value cycle that causes
+// biased item distribution. The original climber.c uses rand() (16-bit)
+// for the same reason, but ushort arithmetic has transpiler limitations.
 static byte rndint(byte a, byte b)
 {
     byte range = (byte)(b - a);
-    byte r = rand8();
+    byte r = (byte)(rand8() ^ rand8());
     return (byte)((byte)(r % range) + a);
 }
 


### PR DESCRIPTION
The original climber.c uses ``rand()`` (cc65 stdlib, 16-bit) for ``rndint``:

```c
// use rand() because rand8() has a cycle of 255
byte rndint(byte a, byte b) {
  return (rand() % (b-a)) + a;
}
```

The dotnes port used single ``rand8()`` (8-bit, 255-value cycle), which produced a PRNG sequence where mines (objtype=1) only appeared on floors 11+. The first 10 visible floors had only hearts and power-ups.

**Fix:** XOR two ``rand8()`` calls to break the cycle correlation:

```csharp
byte r = (byte)(rand8() ^ rand8());
```

**Verified with Mesen2 emulator:**
- Before: ``floor_objtype = [0,2,2,3,3,2,3,3,3,3,3,1,1,3,1,2,1,2,1,0]`` (mines at floor 11+)
- After: ``floor_objtype = [0,2,3,3,1,3,1,2,3,3,1,3,1,1,1,3,1,3,3,0]`` (mines at floor 4+)
- Mine tiles in nametable: 0 -> 8

Fixes #305