### PR TITLE
Add unshipped API review document

### DIFF
--- a/docs/unshipped-api-review.md
+++ b/docs/unshipped-api-review.md
@@ -25,12 +25,13 @@ Compared against the original [neslib.h](https://github.com/clbr/neslib/blob/mas
 `PAD` is already a `[Flags]` enum. `MASK` should follow the same pattern — these are bitflags meant to be OR'd together (`MASK.BG | MASK.SPR`). A `[Flags] enum` gives type safety and lets `ppu_mask()` accept `MASK` instead of raw `byte`.
 
 ```csharp
-// Current (C-style)
-ppu_mask(MASK.BG | MASK.SPR);  // MASK members are byte constants, no type safety
+// Current (C-style) — requires an explicit cast because byte | byte promotes to int
+ppu_mask((byte)(MASK.BG | MASK.SPR));
 
-// Better (C#-style)
+// Better (C#-style) — [Flags] enum lets | work naturally
 [Flags] public enum MASK : byte { ... }
 public static void ppu_mask(MASK mask);
+ppu_mask(MASK.BG | MASK.SPR);  // compiles cleanly, type-safe
 ```
 
 ### 2. `set_chr_mode` should be `mmc3_set_chr_bank`


### PR DESCRIPTION
Review of new APIs in `PublicAPI.Unshipped.txt` comparing against the original neslib.h and the existing shipped C# API.

## Issues filed

**Must fix before shipping:**
- #347 MASK should be a [Flags] enum, not a static class
- #346 Rename set_chr_mode to mmc3_set_chr_bank
- #345 memfill uses wrong parameter type (object dst)
- #338 music_play vs play_music naming confusion
- #343 Missing OAM_FLIP_V, OAM_FLIP_H, OAM_BEHIND constants

**C#-ification opportunities (lower priority):**
- #342 oam_size should use an enum instead of byte
- #340 vram_inc should use a bool or enum instead of byte
- #348 ppu_system should return an enum or bool instead of byte
- #344 MMC1_MIRROR_* constants should be an enum
- #339 music_pause should take bool instead of byte
- #341 oam_off should be a property instead of a public field