### PR TITLE
Fix memfill parameter type: object -> ushort

### DIFF
--- a/src/neslib/NESLib.cs
+++ b/src/neslib/NESLib.cs
@@ -171,9 +171,9 @@ public static class NESLib
     public static void vram_unlz4(byte[] input, byte[] output, uint uncompressedSize) => throw null!;
 
     /// <summary>
-    /// fill memory
+    /// fill memory at an absolute address
     /// </summary>
-    public static void memfill(object dst, byte value, uint len) => throw null!;
+    public static void memfill(ushort addr, byte value, uint len) => throw null!;
 
     /// <summary>
     /// clear OAM buffer fast

--- a/src/neslib/PublicAPI.Unshipped.txt
+++ b/src/neslib/PublicAPI.Unshipped.txt
@@ -62,7 +62,7 @@ static NES.NESLib.cli() -> void
 static NES.NESLib.cnrom_set_chr_bank(byte bank) -> void
 static NES.NESLib.famitone_init(string! musicDataLabel) -> void
 static NES.NESLib.irq_set_callback(delegate*<void> callback) -> void
-static NES.NESLib.memfill(object! dst, byte value, uint len) -> void
+static NES.NESLib.memfill(ushort addr, byte value, uint len) -> void
 static NES.NESLib.mmc1_set_chr_bank(byte bank0, byte bank1) -> void
 static NES.NESLib.mmc1_set_mirroring(byte mode) -> void
 static NES.NESLib.mmc1_set_prg_bank(byte bank) -> void


### PR DESCRIPTION
## Problem

`memfill(object dst, byte value, uint len)` uses `object` as the destination type. The C original is `void *dst`, but NES has no managed objects -- `object` is semantically wrong for a hardware memory fill.

## Fix

Changed to `memfill(ushort addr, byte value, uint len)` to match the `poke`/`peek` pattern, which also use `ushort` for raw memory addresses.

Updated `PublicAPI.Unshipped.txt` to reflect the new signature.

All 600 tests pass.

Fixes #345