### PR TITLE
Support try/finally IL opcodes in the transpiler

### DIFF
--- a/src/dotnes.analyzers.tests/NESAnalyzerTests.cs
+++ b/src/dotnes.analyzers.tests/NESAnalyzerTests.cs
@@ -893,7 +893,7 @@ public class NESAnalyzerTests
         await VerifyAsync(test);
     }
 
-    // ==================== NES011: try/catch/finally not supported ====================
+    // ==================== NES011: try/catch not supported (try/finally is allowed) ====================
 
     [Fact]
     public async Task NES011_TryCatch_Diagnostic()
@@ -908,10 +908,21 @@ public class NESAnalyzerTests
     }
 
     [Fact]
-    public async Task NES011_TryFinally_Diagnostic()
+    public async Task NES011_TryFinally_NoDiagnostic()
     {
         var test = """
-            {|#0:try { } finally { }|}
+            try { } finally { }
+            while (true) ;
+            """;
+
+        await VerifyAsync(test);
+    }
+
+    [Fact]
+    public async Task NES011_TryCatchFinally_Diagnostic()
+    {
+        var test = """
+            {|#0:try { } catch { } finally { }|}
             while (true) ;
             """;
 

--- a/src/dotnes.analyzers/AnalyzerReleases.Shipped.md
+++ b/src/dotnes.analyzers/AnalyzerReleases.Shipped.md
@@ -17,5 +17,5 @@ NES007 | NES | Warning | Recursive functions are not supported
 NES008 | NES | Error | LINQ is not supported
 NES009 | NES | Error | Delegates and lambdas are not supported
 NES010 | NES | Error | foreach loops are not supported
-NES011 | NES | Error | Exception handling is not supported
+NES011 | NES | Error | try/catch is not supported (try/finally is allowed)
 NES012 | NES | Error | Property declarations are not supported

--- a/src/dotnes.analyzers/NESAnalyzer.cs
+++ b/src/dotnes.analyzers/NESAnalyzer.cs
@@ -118,11 +118,11 @@ public class NESAnalyzer : DiagnosticAnalyzer
     static readonly DiagnosticDescriptor NES011Rule = new(
         NES011,
         "Exception handling is not supported",
-        "try/catch/finally is not supported on the NES",
+        "try/catch is not supported on the NES; only try/finally is allowed (for 'using' statements)",
         Category,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The NES 6502 CPU has no exception handling mechanism. Use conditional checks instead.");
+        description: "The NES 6502 CPU has no exception handling mechanism. try/finally is allowed because it lowers to sequential code. try/catch is not supported.");
 
     static readonly DiagnosticDescriptor NES012Rule = new(
         NES012,
@@ -527,7 +527,12 @@ public class NESAnalyzer : DiagnosticAnalyzer
 
     static void AnalyzeTryCatchFinally(SyntaxNodeAnalysisContext context)
     {
-        context.ReportDiagnostic(Diagnostic.Create(NES011Rule, context.Node.GetLocation()));
+        var tryStatement = (TryStatementSyntax)context.Node;
+
+        // try/finally (no catch) is allowed — it lowers to inline code on the NES.
+        // Only report an error if there are catch clauses.
+        if (tryStatement.Catches.Count > 0)
+            context.ReportDiagnostic(Diagnostic.Create(NES011Rule, context.Node.GetLocation()));
     }
 
     static void AnalyzePropertyDeclaration(SyntaxNodeAnalysisContext context)

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
@@ -133,10 +133,9 @@ partial class IL2NESWriter
         ILOpCode.Throw or ILOpCode.Rethrow =>
             $"The IL opcode '{opCode}' is not supported. " +
             "Exception handling ('throw', 'try/catch') is not supported on the NES.",
-        ILOpCode.Leave or ILOpCode.Leave_s or ILOpCode.Endfinally or ILOpCode.Endfilter =>
+        ILOpCode.Endfilter =>
             $"The IL opcode '{opCode}' is not supported. " +
-            "This is typically caused by 'try/catch/finally' blocks. " +
-            "Exception handling is not supported on the NES.",
+            "Exception filters are not supported on the NES.",
         ILOpCode.Newobj =>
             $"The IL opcode '{opCode}' is not supported. " +
             "This is typically caused by creating an object with 'new' (e.g., 'new List<byte>()'), " +

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
@@ -1094,6 +1094,22 @@ partial class IL2NESWriter
                 // Pattern: Ldloc_N (array), Ldloc_M (index), Ldelem_u1
                 HandleLdelemU1();
                 break;
+            case ILOpCode.Endfinally:
+                {
+                    // End of a finally block — jump to the instruction after the handler,
+                    // or fall through if it's already the next instruction.
+                    var region = FindEnclosingHandlerRegion(instruction.Offset);
+                    if (region != null)
+                    {
+                        int afterHandler = region.Value.HandlerOffset + region.Value.HandlerLength;
+                        int nextOffset = instruction.Offset + 1; // endfinally is 1 byte
+                        if (nextOffset != afterHandler)
+                            EmitJMP(InstructionLabel(afterHandler));
+                    }
+                    Stack.Clear();
+                    _accState = AccumulatorState.Empty;
+                }
+                break;
             default:
                 throw new TranspileException(GetUnsupportedOpcodeMessage(instruction.OpCode), MethodName);
         }
@@ -1149,6 +1165,47 @@ partial class IL2NESWriter
                 {
                     var labelName = InstructionLabel(instruction.Offset + operand + 5);
                     EmitJMP(labelName);
+                }
+                break;
+            case ILOpCode.Leave_s:
+                // Exit try block (short form) — jump to finally handler start,
+                // or fall through if the handler is the next instruction.
+                {
+                    var region = FindEnclosingTryRegion(instruction.Offset);
+                    if (region != null)
+                    {
+                        int nextOffset = instruction.Offset + 2; // leave.s is 2 bytes
+                        if (nextOffset != region.Value.HandlerOffset)
+                            EmitJMP(InstructionLabel(region.Value.HandlerOffset));
+                    }
+                    else
+                    {
+                        // No try/finally context — treat as unconditional branch
+                        operand = (sbyte)(byte)operand;
+                        EmitJMP(InstructionLabel(instruction.Offset + operand + 2));
+                    }
+                    Stack.Clear();
+                    _accState = AccumulatorState.Empty;
+                }
+                break;
+            case ILOpCode.Leave:
+                // Exit try block (long form) — jump to finally handler start,
+                // or fall through if the handler is the next instruction.
+                {
+                    var region = FindEnclosingTryRegion(instruction.Offset);
+                    if (region != null)
+                    {
+                        int nextOffset = instruction.Offset + 5; // leave is 5 bytes
+                        if (nextOffset != region.Value.HandlerOffset)
+                            EmitJMP(InstructionLabel(region.Value.HandlerOffset));
+                    }
+                    else
+                    {
+                        // No try/finally context — treat as unconditional branch
+                        EmitJMP(InstructionLabel(instruction.Offset + operand + 5));
+                    }
+                    Stack.Clear();
+                    _accState = AccumulatorState.Empty;
                 }
                 break;
             case ILOpCode.Newarr:

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.cs
@@ -10,6 +10,12 @@ using Local = dotnes.LocalVariableManager.Local;
 namespace dotnes;
 
 /// <summary>
+/// Represents a try/finally region parsed from IL method body metadata.
+/// Used by Leave/Leave_s/Endfinally opcode handlers to inline finally blocks.
+/// </summary>
+internal record struct TryFinallyRegion(int TryOffset, int TryLength, int HandlerOffset, int HandlerLength);
+
+/// <summary>
 /// Transpiles .NET IL instructions into 6502 assembly for the NES.
 /// This is the core class containing fields, properties, and the public API surface.
 /// The IL dispatch, code emission, and optimization logic are in partial class files.
@@ -521,6 +527,36 @@ partial class IL2NESWriter : NESWriter
     /// </summary>
     string InstructionLabel(int offset) =>
         MethodName is null ? $"instruction_{offset:X2}" : $"{MethodName}_instruction_{offset:X2}";
+
+    /// <summary>
+    /// Exception regions (try/finally) parsed from the method body.
+    /// Used by Leave/Leave_s/Endfinally opcode handlers.
+    /// </summary>
+    internal TryFinallyRegion[]? TryFinallyRegions { get; set; }
+
+    /// <summary>
+    /// Finds the try/finally region whose try block contains the given IL offset.
+    /// </summary>
+    TryFinallyRegion? FindEnclosingTryRegion(int offset)
+    {
+        if (TryFinallyRegions == null) return null;
+        foreach (var r in TryFinallyRegions)
+            if (offset >= r.TryOffset && offset < r.TryOffset + r.TryLength)
+                return r;
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the try/finally region whose handler (finally) block contains the given IL offset.
+    /// </summary>
+    TryFinallyRegion? FindEnclosingHandlerRegion(int offset)
+    {
+        if (TryFinallyRegions == null) return null;
+        foreach (var r in TryFinallyRegions)
+            if (offset >= r.HandlerOffset && offset < r.HandlerOffset + r.HandlerLength)
+                return r;
+        return null;
+    }
 
     /// <summary>
     /// Merges a string table entry from a user method writer into this writer.

--- a/src/dotnes.tasks/Utilities/Transpiler.ILParsing.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.ILParsing.cs
@@ -29,6 +29,9 @@ partial class Transpiler
 
             if (methodName == "Main" || methodName == "<Main>$")
             {
+                // Parse exception regions (try/finally) before yielding instructions
+                MainExceptionRegions = ParseExceptionRegions(methodDef);
+
                 // Yield main method instructions
                 foreach (var instruction in ReadMethodBody(methodDef, arrayValues))
                     yield return instruction;
@@ -84,6 +87,11 @@ partial class Transpiler
                 var instructions = ReadMethodBody(methodDef, arrayValues).ToArray();
                 UserMethods[cleanName] = instructions;
 
+                // Parse exception regions (try/finally) for user methods
+                var userRegions = ParseExceptionRegions(methodDef);
+                if (userRegions.Length > 0)
+                    UserMethodExceptionRegions[cleanName] = userRegions;
+
                 // Extract metadata from method signature blob
                 var sig = _reader.GetBlobReader(methodDef.Signature);
                 sig.ReadByte(); // calling convention
@@ -104,6 +112,38 @@ partial class Transpiler
                 UserMethodMetadata[cleanName] = (paramCount, hasReturnValue, isArrayParam);
             }
         }
+    }
+
+    /// <summary>
+    /// Parses structured exception handling (SEH) clauses from a method body.
+    /// Only try/finally regions are supported; try/catch and filters produce an error.
+    /// </summary>
+    TryFinallyRegion[] ParseExceptionRegions(MethodDefinition methodDef)
+    {
+        var body = _pe.GetMethodBody(methodDef.RelativeVirtualAddress);
+        if (body.ExceptionRegions.Length == 0)
+            return [];
+
+        var regions = new List<TryFinallyRegion>();
+        foreach (var region in body.ExceptionRegions)
+        {
+            switch (region.Kind)
+            {
+                case ExceptionRegionKind.Finally:
+                    regions.Add(new TryFinallyRegion(
+                        region.TryOffset, region.TryLength,
+                        region.HandlerOffset, region.HandlerLength));
+                    break;
+                case ExceptionRegionKind.Catch:
+                    throw new TranspileException(
+                        "try/catch blocks are not supported on the NES. " +
+                        "Only try/finally is supported (for 'using' statements).", null);
+                default:
+                    throw new TranspileException(
+                        $"Exception region kind '{region.Kind}' is not supported on the NES.", null);
+            }
+        }
+        return regions.ToArray();
     }
 
     IEnumerable<ILInstruction> ReadMethodBody(MethodDefinition methodDef, Dictionary<string, ArrayValue> arrayValues)

--- a/src/dotnes.tasks/Utilities/Transpiler.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.cs
@@ -46,6 +46,18 @@ partial class Transpiler : IDisposable
     public Dictionary<string, (int argCount, bool hasReturnValue)> ExternMethods { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Exception regions (try/finally) for the main method.
+    /// Populated by ReadStaticVoidMain().
+    /// </summary>
+    internal TryFinallyRegion[] MainExceptionRegions { get; private set; } = [];
+
+    /// <summary>
+    /// Exception regions (try/finally) for user-defined methods (name -> regions).
+    /// Populated by ReadStaticVoidMain().
+    /// </summary>
+    internal Dictionary<string, TryFinallyRegion[]> UserMethodExceptionRegions { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
     /// Closure field types: field name → size (-1 for byte[], positive for scalars).
     /// Populated by DetectStructLayouts() when compiler-generated DisplayClass types are found.
     /// </summary>
@@ -278,6 +290,7 @@ partial class Transpiler : IDisposable
             ClosureFieldLabels = _closureFieldLabels,
             ClosureFieldAddresses = _closureFieldAddresses,
             ClosureStructLocalIndex = _closureStructLocalIndex,
+            TryFinallyRegions = MainExceptionRegions.Length > 0 ? MainExceptionRegions : null,
         };
 
         writer.StartBlockBuffering();
@@ -365,6 +378,7 @@ partial class Transpiler : IDisposable
                 ClosureFieldLabels = _closureFieldLabels,
                 ClosureFieldAddresses = _closureFieldAddresses,
                 ClosureArgIndex = _closureMethodArgIndex.TryGetValue(methodName, out var cai) ? cai : -1,
+                TryFinallyRegions = UserMethodExceptionRegions.TryGetValue(methodName, out var umer) ? umer : null,
             };
             methodWriter.StartBlockBuffering();
 

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -5398,4 +5398,63 @@ public class RoslynTests
             "User method with early 'return 1' must JMP to epilogue. " +
             "Without it, A is overwritten by 'return 0' and the function always returns 0.");
     }
+
+    [Fact]
+    public void TryFinally()
+    {
+        // try/finally inlines both blocks sequentially — no exception handling needed on the NES.
+        // The leave/endfinally opcodes fall through when the code is linear.
+        AssertProgram(
+            csharpSource:
+                """
+                pal_col(0, 0x02);
+                try
+                {
+                    pal_col(1, 0x14);
+                }
+                finally
+                {
+                    pal_col(2, 0x20);
+                }
+                ppu_on_all();
+                while (true) ;
+                """,
+            expectedAssembly:
+                """
+                A900    ; LDA #$00
+                208385  ; JSR pusha
+                A902    ; LDA #$02
+                203E82  ; JSR pal_col
+                A901    ; LDA #$01
+                208385  ; JSR pusha
+                A914    ; LDA #$14
+                203E82  ; JSR pal_col
+                A902    ; LDA #$02
+                208385  ; JSR pusha
+                A920    ; LDA #$20
+                203E82  ; JSR pal_col
+                208982  ; JSR ppu_on_all
+                4C2185  ; JMP (infinite loop)
+                """);
+    }
+
+    [Fact]
+    public void TryCatch_Throws()
+    {
+        // try/catch must still be rejected — the NES has no exception handling.
+        var ex = Assert.Throws<TranspileException>(() =>
+            GetProgramBytes(
+                """
+                try
+                {
+                    ppu_on_all();
+                }
+                catch
+                {
+                    ppu_off();
+                }
+                while (true) ;
+                """));
+        Assert.Contains("try/catch", ex.Message);
+    }
 }


### PR DESCRIPTION
Parse structured exception handling (SEH) clauses from method body metadata and handle `Leave`, `Leave_s`, and `Endfinally` opcodes so `try/finally` blocks (used by C# `using` statements) transpile to inline 6502 code.

## Changes

**Transpiler core** (`Transpiler.ILParsing.cs`, `Transpiler.cs`):
- Parse `MethodBodyBlock.ExceptionRegions` to extract try/finally regions
- Reject `try/catch` and filter regions with clear error messages
- Pass exception region data to `IL2NESWriter` for both main and user methods

**IL opcode handling** (`IL2NESWriter.cs`, `IL2NESWriter.ILDispatch.cs`, `IL2NESWriter.Helpers.cs`):
- Add `TryFinallyRegion` record struct and lookup helpers
- Handle `Leave`/`Leave_s` as JMP to finally handler start (optimized to fall-through when linear)
- Handle `Endfinally` as JMP past handler end (optimized to fall-through when linear)
- Remove these opcodes from the unsupported error message; keep `Endfilter` as unsupported

**Roslyn analyzer** (`NESAnalyzer.cs`, `NESAnalyzerTests.cs`):
- NES011 now only flags `try/catch` (has catch clauses), not `try/finally`
- Updated diagnostic message and description
- Added `NES011_TryCatchFinally_Diagnostic` test for try/catch/finally combo

**Test sample** (`samples/tryfinally/`):
- New sample demonstrating try/finally with `pal_col` calls
- Debug and release test DLLs added to `Data/`
- `ReadStaticVoidMain` and `Write` snapshot tests

## IL structure handled

```
.try {
    // body code
    leave     IL_target
}
finally {
    // cleanup code
    endfinally
}
IL_target:
    // code after
```

Transpiles to sequential 6502: body code, then cleanup code, then code after (no exception machinery needed).

## Test results

All 618 tests pass (553 transpiler + 65 analyzer).

Closes #428