### PR TITLE
Add test for oam_begin inside loop body

### DIFF
--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -5571,4 +5571,34 @@ public class RoslynTests
             il.Instruction.Operand is LabelOperand lbl && lbl.Label == "oam_hide_rest");
         Assert.True(hasOamHideRest, "Expected JSR oam_hide_rest from OamFrame.Dispose() in main block");
     }
+
+    [Fact]
+    public void OamBegin_InsideLoopBody_EmitsCorrectOrdering()
+    {
+        // Realistic game loop: oam_begin inside while(true), Dispose called each iteration
+        var (program, _) = BuildProgram(
+            """
+            ppu_on_all();
+            while (true)
+            {
+                ppu_wait_nmi();
+                using var frame = oam_begin();
+                oam_spr(10, 20, 0x01, 0, 0);
+            }
+            """);
+
+        var mainBlock = program.Blocks.Single(b => b.Label == "main");
+        var jsrLabels = mainBlock.InstructionsWithLabels
+            .Where(il => il.Instruction.Opcode == Opcode.JSR && il.Instruction.Operand is LabelOperand)
+            .Select(il => ((LabelOperand)il.Instruction.Operand!).Label)
+            .ToList();
+
+        // oam_clear (from oam_begin) must appear before oam_hide_rest (from Dispose)
+        int clearIndex = jsrLabels.IndexOf("oam_clear");
+        int hideRestIndex = jsrLabels.IndexOf("oam_hide_rest");
+        Assert.True(clearIndex >= 0, "Expected JSR oam_clear from oam_begin()");
+        Assert.True(hideRestIndex >= 0, "Expected JSR oam_hide_rest from OamFrame.Dispose()");
+        Assert.True(clearIndex < hideRestIndex,
+            $"oam_clear (index {clearIndex}) should come before oam_hide_rest (index {hideRestIndex})");
+    }
 }

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -5588,16 +5588,24 @@ public class RoslynTests
             """);
 
         var mainBlock = program.Blocks.Single(b => b.Label == "main");
-        var jsrLabels = mainBlock.InstructionsWithLabels
-            .Where(il => il.Instruction.Opcode == Opcode.JSR && il.Instruction.Operand is LabelOperand)
-            .Select(il => ((LabelOperand)il.Instruction.Operand!).Label)
-            .ToList();
+        var instructions = mainBlock.InstructionsWithLabels.ToList();
 
-        // oam_clear (from oam_begin) must appear before oam_hide_rest (from Dispose)
-        int clearIndex = jsrLabels.IndexOf("oam_clear");
-        int hideRestIndex = jsrLabels.IndexOf("oam_hide_rest");
+        static bool IsJsrTo((Instruction Instruction, string? Label) il, string label) =>
+            il.Instruction.Opcode == Opcode.JSR &&
+            il.Instruction.Operand is LabelOperand lbl &&
+            lbl.Label == label;
+
+        int loopStartIndex= instructions.FindIndex(il => IsJsrTo(il, "ppu_wait_nmi"));
+        int clearIndex = instructions.FindIndex(il => IsJsrTo(il, "oam_clear"));
+        int hideRestIndex = instructions.FindIndex(il => IsJsrTo(il, "oam_hide_rest"));
+
+        Assert.True(loopStartIndex >= 0, "Expected JSR ppu_wait_nmi at start of loop body");
         Assert.True(clearIndex >= 0, "Expected JSR oam_clear from oam_begin()");
         Assert.True(hideRestIndex >= 0, "Expected JSR oam_hide_rest from OamFrame.Dispose()");
+
+        // Both OAM calls must be inside the loop body (after ppu_wait_nmi)
+        Assert.True(loopStartIndex < clearIndex,
+            $"oam_clear (index {clearIndex}) should be inside loop body after ppu_wait_nmi (index {loopStartIndex})");
         Assert.True(clearIndex < hideRestIndex,
             $"oam_clear (index {clearIndex}) should come before oam_hide_rest (index {hideRestIndex})");
     }


### PR DESCRIPTION
Adds a test for the realistic game loop pattern where `using var frame = oam_begin()` is called inside a `while(true)` loop body.

The existing tests in #448 verified oam_begin/Dispose with `using var` at the top level (where Dispose ends up after `while(true);` — unreachable). This new test exercises the intended usage where `oam_begin()` is scoped inside the loop, so `OamFrame.Dispose()` is called each iteration.

**What the test verifies:**
- `JSR oam_clear` (from `oam_begin()`) is emitted before `JSR oam_hide_rest` (from `OamFrame.Dispose()`) in the main block
- Both subroutine calls are present in the correct order within the loop

Relates to #430