### PR TITLE
Fix GetStlocIndex to take ILInstruction instead of ILOpCode

### DIFF
--- a/src/dotnes.tasks/Utilities/IL2NESWriter.Arithmetic.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.Arithmetic.cs
@@ -490,10 +490,7 @@ partial class IL2NESWriter
             var next1 = Instructions[Index + 1];
             var next2 = Instructions[Index + 2];
             
-            int? storeLocalIndex = GetStlocIndex(next2.OpCode);
-            // For Stloc_s, the local index is in the instruction's operand
-            if (storeLocalIndex is null && next2.OpCode == ILOpCode.Stloc_s)
-                storeLocalIndex = next2.Integer;
+            int? storeLocalIndex = GetStlocIndex(next2);
             
             if ((next1.OpCode == ILOpCode.Conv_u1 || next1.OpCode == ILOpCode.Conv_u2 ||
                  next1.OpCode == ILOpCode.Conv_u4 || next1.OpCode == ILOpCode.Conv_u8) &&

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.Arithmetic.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.Arithmetic.cs
@@ -490,7 +490,7 @@ partial class IL2NESWriter
             var next1 = Instructions[Index + 1];
             var next2 = Instructions[Index + 2];
             
-            int? storeLocalIndex = GetStlocIndex(next2);
+            int? storeLocalIndex = next2.GetStlocIndex();
             
             if ((next1.OpCode == ILOpCode.Conv_u1 || next1.OpCode == ILOpCode.Conv_u2 ||
                  next1.OpCode == ILOpCode.Conv_u4 || next1.OpCode == ILOpCode.Conv_u8) &&

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
@@ -13,19 +13,6 @@ namespace dotnes;
 partial class IL2NESWriter
 {
     /// <summary>
-    /// Gets the local index for a Stloc opcode, or null if not a Stloc.
-    /// </summary>
-    static int? GetStlocIndex(ILInstruction instr) => instr.OpCode switch
-    {
-        ILOpCode.Stloc_0 => 0,
-        ILOpCode.Stloc_1 => 1,
-        ILOpCode.Stloc_2 => 2,
-        ILOpCode.Stloc_3 => 3,
-        ILOpCode.Stloc_s or ILOpCode.Stloc => instr.Integer,
-        _ => null
-    };
-
-    /// <summary>
     /// Gets the local index from a Ldloc instruction.
     /// </summary>
     static int? GetLdlocIndex(ILInstruction instr) => instr.OpCode switch

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.Helpers.cs
@@ -15,14 +15,13 @@ partial class IL2NESWriter
     /// <summary>
     /// Gets the local index for a Stloc opcode, or null if not a Stloc.
     /// </summary>
-    static int? GetStlocIndex(ILOpCode opCode) => opCode switch
+    static int? GetStlocIndex(ILInstruction instr) => instr.OpCode switch
     {
         ILOpCode.Stloc_0 => 0,
         ILOpCode.Stloc_1 => 1,
         ILOpCode.Stloc_2 => 2,
         ILOpCode.Stloc_3 => 3,
-        ILOpCode.Stloc => null, // Would need operand
-        ILOpCode.Stloc_s => null, // Would need operand  
+        ILOpCode.Stloc_s or ILOpCode.Stloc => instr.Integer,
         _ => null
     };
 

--- a/src/dotnes.tasks/Utilities/ILInstruction.cs
+++ b/src/dotnes.tasks/Utilities/ILInstruction.cs
@@ -6,4 +6,18 @@ namespace dotnes;
 /// <summary>
 /// Holds info about IL
 /// </summary>
-record ILInstruction(ILOpCode OpCode, int Offset = 0, int? Integer = null, string? String = null, ImmutableArray<byte>? Bytes = null);
+record ILInstruction(ILOpCode OpCode, int Offset = 0, int? Integer = null, string? String = null, ImmutableArray<byte>? Bytes = null)
+{
+    /// <summary>
+    /// Gets the local index for a Stloc opcode, or null if not a Stloc.
+    /// </summary>
+    public int? GetStlocIndex() => OpCode switch
+    {
+        ILOpCode.Stloc_0 => 0,
+        ILOpCode.Stloc_1 => 1,
+        ILOpCode.Stloc_2 => 2,
+        ILOpCode.Stloc_3 => 3,
+        ILOpCode.Stloc_s or ILOpCode.Stloc => Integer,
+        _ => null
+    };
+}

--- a/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
@@ -91,7 +91,7 @@ partial class Transpiler
             {
                 if (instructions[j].OpCode == ILOpCode.Dup)
                     continue;
-                int? stlocIdx = GetStlocIndex(instructions[j]);
+                int? stlocIdx = instructions[j].GetStlocIndex();
                 if (stlocIdx.HasValue)
                     newarrStlocTargets.Add(stlocIdx.Value);
                 break;
@@ -102,7 +102,7 @@ partial class Transpiler
         var countedLocals = new HashSet<int>();
         for (int i = 0; i < instructions.Length; i++)
         {
-            int? stlocIdx = GetStlocIndex(instructions[i]);
+            int? stlocIdx = instructions[i].GetStlocIndex();
             if (stlocIdx.HasValue
                 && !countedLocals.Contains(stlocIdx.Value)
                 && !newarrStlocTargets.Contains(stlocIdx.Value))
@@ -163,16 +163,6 @@ partial class Transpiler
 
         return totalBytes;
     }
-
-    static int? GetStlocIndex(ILInstruction inst) => inst.OpCode switch
-    {
-        ILOpCode.Stloc_0 => 0,
-        ILOpCode.Stloc_1 => 1,
-        ILOpCode.Stloc_2 => 2,
-        ILOpCode.Stloc_3 => 3,
-        ILOpCode.Stloc_s or ILOpCode.Stloc => inst.Integer,
-        _ => null
-    };
 
     static int? GetLdcValue(ILInstruction inst) => inst.OpCode switch
     {

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -6402,4 +6402,41 @@ public class RoslynTests
         Assert.Equal(Opcode.ORA, oraInstr.Opcode);
         Assert.Equal(0xF0, ((ImmediateOperand)oraInstr.Operand!).Value);
     }
+
+    [Fact]
+    public void IncrementLocalIndex4_UsesStlocS()
+    {
+        // Regression test for #485: GetStlocIndex must handle Stloc_s (local index > 3).
+        // With 5+ locals, the compiler uses Stloc_s for the 5th local (index 4).
+        // Before the fix, GetStlocIndex returned null for Stloc_s, so the x++ pattern
+        // was not detected and the less efficient pushax/popax path was used instead of INC.
+        var bytes = GetProgramBytes(
+            """
+            byte a = 1;
+            byte b = 2;
+            byte c = 3;
+            byte d = 4;
+            byte e = 5;
+            pal_col(0, a);
+            pal_col(1, b);
+            pal_col(2, c);
+            pal_col(3, d);
+            ppu_on_all();
+            while (true)
+            {
+                ppu_wait_nmi();
+                e++;
+                pal_col(0, e);
+            }
+            """);
+        Assert.NotNull(bytes);
+        Assert.NotEmpty(bytes);
+
+        var hex = Convert.ToHexString(bytes);
+        _logger.WriteLine($"IncrementLocalIndex4 hex: {hex}");
+
+        // Local e (index 4) is at address $0329. INC absolute = EE.
+        // The optimized x++ pattern should emit EE2903 (INC $0329).
+        Assert.Contains("EE2903", hex);
+    }
 }


### PR DESCRIPTION
Fixes #485

## Problem

`GetStlocIndex` in `IL2NESWriter.Helpers.cs` took `ILOpCode` instead of `ILInstruction`, making it impossible to extract the operand for `Stloc_s` and `Stloc` — it returned `null` for any local variable with index > 3.

## Fix

- Changed the Helpers version to accept `ILInstruction` (matching the correct version in `Transpiler.LocalFrameAllocation.cs`)
- Removed the manual workaround in `IL2NESWriter.Arithmetic.cs` that was compensating for the broken signature