### PR TITLE
Add bounds check to Block.RemoveLast

### DIFF
--- a/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
@@ -1289,7 +1289,7 @@ partial class IL2NESWriter
                                 RemoveLastInstructions(toRemove);
                         }
 
-                        // Check if this is a music note table(newarr; dup; ldtoken; InitializeArray)
+                        // Check if this is a music note table (newarr; dup; ldtoken; InitializeArray)
                         // vs a regular ushort array (newarr; dup; ldc; ldc; stelem).
                         // Only pre-allocate zero-page space for regular arrays.
                         bool isMusicTable = Instructions != null

--- a/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.ILDispatch.cs
@@ -1267,7 +1267,8 @@ partial class IL2NESWriter
                         if (isLdcPrevious)
                         {
                             int toRemove = Stack.Count > 0 && Stack.Peek() > byte.MaxValue ? 2 : 1;
-                            RemoveLastInstructions(toRemove);
+                            if (GetBufferedBlockCount() >= toRemove)
+                                RemoveLastInstructions(toRemove);
                         }
                         _pendingStructArrayCount = Stack.Count > 0 ? Stack.Peek() : 0;
                         // Pre-allocate the struct array now (optimizer uses dup before stloc)
@@ -1284,10 +1285,11 @@ partial class IL2NESWriter
                         if (isLdcPrevious)
                         {
                             int toRemove = Stack.Count > 0 && Stack.Peek() > byte.MaxValue ? 2 : 1;
-                            RemoveLastInstructions(toRemove);
+                            if (GetBufferedBlockCount() >= toRemove)
+                                RemoveLastInstructions(toRemove);
                         }
 
-                        // Check if this is a music note table (newarr; dup; ldtoken; InitializeArray)
+                        // Check if this is a music note table(newarr; dup; ldtoken; InitializeArray)
                         // vs a regular ushort array (newarr; dup; ldc; ldc; stelem).
                         // Only pre-allocate zero-page space for regular arrays.
                         bool isMusicTable = Instructions != null
@@ -1307,7 +1309,8 @@ partial class IL2NESWriter
                     {
                         // Remove LDA emitted for the array size constant
                         int toRemove = Stack.Count > 0 && Stack.Peek() > byte.MaxValue ? 2 : 1;
-                        RemoveLastInstructions(toRemove);
+                        if (GetBufferedBlockCount() >= toRemove)
+                            RemoveLastInstructions(toRemove);
                     }
                     // Track the array element type so the next Ldtoken can handle non-byte arrays
                     _pendingArrayType = instruction.String;

--- a/src/dotnes.tasks/Utilities/NESWriter.cs
+++ b/src/dotnes.tasks/Utilities/NESWriter.cs
@@ -202,7 +202,11 @@ class NESWriter : IDisposable
     {
         if (_bufferedBlock == null)
             throw new InvalidOperationException("RemoveLastInstructions called but not in block buffering mode");
-        
+
+        if (_bufferedBlock.Count < count)
+            throw new InvalidOperationException(
+                $"Cannot remove {count} instruction(s): only {_bufferedBlock.Count} available in block");
+
         LastLDA = false;
         _logger.WriteLine($"Removing last {count} instruction(s) from block");
         _bufferedBlock.RemoveLast(count);

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -6402,4 +6402,21 @@ public class RoslynTests
         Assert.Equal(Opcode.ORA, oraInstr.Opcode);
         Assert.Equal(0xF0, ((ImmediateOperand)oraInstr.Operand!).Value);
     }
+
+    [Fact]
+    public void MetaSpr2x2BeforeNewarrDoesNotThrow()
+    {
+        // Regression test for #484: meta_spr_2x2 removes its argument LDAs from
+        // the block, then the subsequent newarr handler tried to remove an LDA
+        // that no longer existed, causing an InvalidOperationException.
+        var bytes = GetProgramBytes(
+            """
+            byte[] metasprite = meta_spr_2x2(0xD8, 0xD9, 0xDA, 0xDB);
+            byte[] actor_x = new byte[16];
+            byte[] actor_y = new byte[16];
+            while (true) ;
+            """);
+        Assert.NotNull(bytes);
+        Assert.NotEmpty(bytes);
+    }
 }


### PR DESCRIPTION
## Summary

`RemoveLastInstructions` now throws `InvalidOperationException` when asked to remove more instructions than exist in the block, catching silent data corruption bugs in the transpiler.

The `Newarr` handler in `ILDispatch.cs` assumed the LDA for the array size constant was always in the block, but intrinsics like `meta_spr_2x2` can remove those instructions first. Added buffer count guards to all three `Newarr` branches (struct, ushort, byte arrays).

## Changes

- **NESWriter.cs**: Added bounds check in `RemoveLastInstructions` — throws if `count > block.Count`
- **IL2NESWriter.ILDispatch.cs**: Added `GetBufferedBlockCount() >= toRemove` guards to all three `Newarr` branches to handle cases where prior intrinsics already cleaned up the buffer

## Testing

All 652 tests pass (584 dotnes + 68 analyzers), including the `metasprites` and `snake` samples that were previously silently producing incorrect code.

Fixes #484