### PR TITLE
Add overflow check for static field allocation in NES RAM

### DIFF
--- a/src/dotnes.tasks/Utilities/IL2NESWriter.cs
+++ b/src/dotnes.tasks/Utilities/IL2NESWriter.cs
@@ -479,7 +479,7 @@ partial class IL2NESWriter : NESWriter
     ushort _structArrayBaseForRuntimeIndex;
 
     /// <summary>
-    /// Cumulative bytes allocated for locals on zero page.
+    /// Cumulative bytes allocated for locals in NES RAM ($0325+).
     /// Forwarded to <see cref="Variables"/>.
     /// </summary>
     public int LocalCount { get => Variables.LocalCount; set => Variables.LocalCount = value; }

--- a/src/dotnes.tasks/Utilities/LocalVariableManager.cs
+++ b/src/dotnes.tasks/Utilities/LocalVariableManager.cs
@@ -28,7 +28,7 @@ class LocalVariableManager
     int _localCount;
 
     /// <summary>
-    /// Cumulative bytes allocated for locals on zero page.
+    /// Cumulative bytes allocated for locals in NES RAM ($0325+).
     /// A program with 0 locals has a base address at <see cref="LocalStackBase"/>.
     /// Throws <see cref="TranspileException"/> if the allocation exceeds NES RAM.
     /// </summary>

--- a/src/dotnes.tasks/Utilities/LocalVariableManager.cs
+++ b/src/dotnes.tasks/Utilities/LocalVariableManager.cs
@@ -25,11 +25,25 @@ class LocalVariableManager
     /// </summary>
     public Dictionary<int, Local> Locals { get; } = new();
 
+    int _localCount;
+
     /// <summary>
     /// Cumulative bytes allocated for locals on zero page.
     /// A program with 0 locals has a base address at <see cref="LocalStackBase"/>.
+    /// Throws <see cref="TranspileException"/> if the allocation exceeds NES RAM.
     /// </summary>
-    public int LocalCount { get; set; }
+    public int LocalCount
+    {
+        get => _localCount;
+        set
+        {
+            if (value > MaxLocalBytes)
+                throw new TranspileException(
+                    $"Local variables and static fields require {value} bytes but only {MaxLocalBytes} bytes are available " +
+                    $"in NES RAM (${LocalStackBase:X4}–$07FF). Reduce the number or size of variables and fields.");
+            _localCount = value;
+        }
+    }
 
     /// <summary>
     /// Local variable indices that are word-sized (ushort). Detected by pre-scanning

--- a/src/dotnes.tasks/Utilities/NESConstants.cs
+++ b/src/dotnes.tasks/Utilities/NESConstants.cs
@@ -44,6 +44,12 @@ internal static class NESConstants
     // Local variable storage
     public const ushort LocalStackBase = 0x0325;
 
+    /// <summary>
+    /// Maximum bytes available for local variables and static fields.
+    /// NES internal RAM ends at $0800; locals/statics start at <see cref="LocalStackBase"/>.
+    /// </summary>
+    public const int MaxLocalBytes = 0x0800 - LocalStackBase;
+
     // PRG ROM
     public const ushort PrgRomStart = 0x8000;
 

--- a/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
@@ -324,6 +324,10 @@ partial class Transpiler
                 offset += (ushort)size;
                 _logger.WriteLine($"Static field '{name}' allocated at ${addresses[name]:X4} ({size} byte{(size > 1 ? "s" : "")})");
             }
+            if (offset > NESConstants.MaxLocalBytes)
+                throw new TranspileException(
+                    $"Static fields require {offset} bytes but only {NESConstants.MaxLocalBytes} bytes are available in NES RAM ($0325–$07FF). " +
+                    "Reduce the number or size of static fields.");
         }
         return (addresses, wordFields, offset, arrayFields);
     }

--- a/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.LocalFrameAllocation.cs
@@ -304,7 +304,7 @@ partial class Transpiler
         var addresses = new Dictionary<string, ushort>(StringComparer.Ordinal);
         var wordFields = new HashSet<string>(StringComparer.Ordinal);
         var arrayFields = new Dictionary<string, (ushort Address, int ArraySize)>(StringComparer.Ordinal);
-        ushort offset = 0;
+        int offset = 0;
         foreach (var name in fieldNames.OrderBy(n => n, StringComparer.Ordinal))
         {
             addresses[name] = (ushort)(NESConstants.LocalStackBase + offset);
@@ -314,14 +314,14 @@ partial class Transpiler
                 // Array field: negative size encodes array byte count
                 int arraySize = -size;
                 arrayFields[name] = ((ushort)(NESConstants.LocalStackBase + offset), arraySize);
-                offset += (ushort)arraySize;
+                offset += arraySize;
                 _logger.WriteLine($"Static field '{name}' allocated at ${addresses[name]:X4} (byte[{arraySize}])");
             }
             else
             {
                 if (size > 1)
                     wordFields.Add(name);
-                offset += (ushort)size;
+                offset += size;
                 _logger.WriteLine($"Static field '{name}' allocated at ${addresses[name]:X4} ({size} byte{(size > 1 ? "s" : "")})");
             }
             if (offset > NESConstants.MaxLocalBytes)

--- a/src/dotnes.tasks/Utilities/Transpiler.StructAnalysis.cs
+++ b/src/dotnes.tasks/Utilities/Transpiler.StructAnalysis.cs
@@ -374,6 +374,10 @@ partial class Transpiler
             int size = Math.Min(kvp.Value, 2); // NES is 8-bit; 16-bit is max for address math
             _closureFieldAddresses[kvp.Key] = (ushort)(NESConstants.LocalStackBase + staticFieldBytes);
             staticFieldBytes += size;
+            if (staticFieldBytes > NESConstants.MaxLocalBytes)
+                throw new TranspileException(
+                    $"Static and closure fields require {staticFieldBytes} bytes but only {NESConstants.MaxLocalBytes} bytes are available in NES RAM ($0325–$07FF). " +
+                    "Reduce the number or size of fields.");
             _logger.WriteLine($"Closure field '{kvp.Key}' allocated at ${_closureFieldAddresses[kvp.Key]:X4} ({size} byte{(size > 1 ? "s" : "")})");
         }
     }

--- a/src/dotnes.tests/LocalVariableManagerTests.cs
+++ b/src/dotnes.tests/LocalVariableManagerTests.cs
@@ -229,4 +229,21 @@ public class LocalVariableManagerTests
         Assert.Equal("Position", manager.GetStructType(1));
         Assert.True(manager.IsStructLocal(1));
     }
+
+    [Fact]
+    public void LocalCount_AtMaxLocalBytes_Succeeds()
+    {
+        var manager = new LocalVariableManager();
+        manager.LocalCount = NESConstants.MaxLocalBytes;
+        Assert.Equal(NESConstants.MaxLocalBytes, manager.LocalCount);
+    }
+
+    [Fact]
+    public void LocalCount_ExceedsMaxLocalBytes_Throws()
+    {
+        var manager = new LocalVariableManager();
+        var ex = Assert.Throws<TranspileException>(() =>
+            manager.LocalCount = NESConstants.MaxLocalBytes + 1);
+        Assert.Contains("NES RAM", ex.Message);
+    }
 }

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -6428,7 +6428,8 @@ public class RoslynTests
 
         var ex = Assert.Throws<TranspileException>(() =>
             GetProgramBytes(source));
-        Assert.Contains("bytes", ex.Message);
+        Assert.Contains("1300 bytes", ex.Message);
         Assert.Contains("NES RAM", ex.Message);
+        Assert.Contains("$0325", ex.Message);
     }
 }

--- a/src/dotnes.tests/RoslynTests.cs
+++ b/src/dotnes.tests/RoslynTests.cs
@@ -6402,4 +6402,33 @@ public class RoslynTests
         Assert.Equal(Opcode.ORA, oraInstr.Opcode);
         Assert.Equal(0xF0, ((ImmediateOperand)oraInstr.Operand!).Value);
     }
+
+    [Fact]
+    public void StaticFieldOverflow_Throws()
+    {
+        // Allocating too many static fields must throw, not silently corrupt memory.
+        // MaxLocalBytes is 0x0800 - 0x0325 = 1243 bytes.
+        // 13 byte[100] arrays = 1300 bytes, which exceeds the limit.
+        var fieldDecls = new System.Text.StringBuilder();
+        var fieldUsage = new System.Text.StringBuilder();
+        for (int i = 0; i < 13; i++)
+        {
+            fieldDecls.AppendLine($"    public static byte[] f{i:D2};");
+            fieldUsage.AppendLine($"G.f{i:D2} = new byte[100];");
+        }
+
+        var source = fieldUsage.ToString() + """
+
+            ppu_on_all();
+            while (true) ;
+
+            static class G
+            {
+            """ + fieldDecls.ToString() + "}";
+
+        var ex = Assert.Throws<TranspileException>(() =>
+            GetProgramBytes(source));
+        Assert.Contains("bytes", ex.Message);
+        Assert.Contains("NES RAM", ex.Message);
+    }
 }


### PR DESCRIPTION
When static fields or local variables exceed the available NES RAM (`$0325`–`$07FF` = 1243 bytes), the transpiler now throws a clear `TranspileException` instead of silently wrapping via `ushort` truncation and causing memory corruption.

## Changes

- **`NESConstants.cs`** — Added `MaxLocalBytes` constant (0x0800 - LocalStackBase = 1243)
- **`LocalVariableManager.cs`** — Centralized overflow check in the `LocalCount` setter, catching all allocation paths (static fields, closure fields, local arrays, etc.)
- **`Transpiler.LocalFrameAllocation.cs`** — Added specific overflow check after each static field allocation for a targeted error message
- **`Transpiler.StructAnalysis.cs`** — Added specific overflow check after each closure field allocation
- **`RoslynTests.cs`** — Added `StaticFieldOverflow_Throws` test verifying that allocating 1300 bytes of static fields throws

All 653 tests pass.

Fixes #486