### PR TITLE
Ignore github/gh-aw-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # gh-aw lock files must be updated via `gh aw compile`, not individual
+      # SHA bumps. Partial version bumps break the workflow.
+      - dependency-name: "github/gh-aw-actions"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem

Dependabot PR #495 bumped only the `github/gh-aw-actions/setup` SHA in the lock file without recompiling, which broke the reviewer workflow (fixed in #504).

The gh-aw lock file must always be updated as a whole via `gh aw compile` — partial SHA bumps create version mismatches.

## Fix

Add an ignore rule for `github/gh-aw-actions` in `.github/dependabot.yml` to prevent this class of breakage from recurring.