### PR TITLE
Bump version to 0.3.3 and ship all unshipped APIs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <PackageVersion>$(Version)-beta</PackageVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DownloadFileRetries>3</DownloadFileRetries>

--- a/src/neslib/PublicAPI.Shipped.txt
+++ b/src/neslib/PublicAPI.Shipped.txt
@@ -258,3 +258,13 @@ NES.PulseChannel.Pulse1 = 0 -> NES.PulseChannel
 NES.PulseChannel.Pulse2 = 1 -> NES.PulseChannel
 static NES.NESLib.apu_play_tone(NES.PulseChannel channel, ushort period, NES.APUDuty duty, byte volume) -> void
 static NES.NESLib.apu_stop(NES.PulseChannel channel) -> void
+static NES.NESLib.clear_vram_buffer() -> void
+static NES.NESLib.get_frame_count() -> byte
+static NES.NESLib.get_pad_new(byte pad) -> NES.PAD
+static NES.NESLib.get_ppu_addr(byte nt, byte x, byte y) -> ushort
+static NES.NESLib.multi_vram_buffer_horz(byte[]! data, byte len, ushort ppuAddress) -> void
+static NES.NESLib.multi_vram_buffer_vert(byte[]! data, byte len, ushort ppuAddress) -> void
+static NES.NESLib.one_vram_buffer(byte data, ushort ppuAddress) -> void
+static NES.NESLib.set_music_speed(byte tempo) -> void
+static NES.NESLib.set_scroll_x(ushort x) -> void
+static NES.NESLib.set_scroll_y(ushort y) -> void

--- a/src/neslib/PublicAPI.Unshipped.txt
+++ b/src/neslib/PublicAPI.Unshipped.txt
@@ -1,11 +1,1 @@
 #nullable enable
-static NES.NESLib.clear_vram_buffer() -> void
-static NES.NESLib.get_frame_count() -> byte
-static NES.NESLib.get_pad_new(byte pad) -> NES.PAD
-static NES.NESLib.get_ppu_addr(byte nt, byte x, byte y) -> ushort
-static NES.NESLib.multi_vram_buffer_horz(byte[]! data, byte len, ushort ppuAddress) -> void
-static NES.NESLib.multi_vram_buffer_vert(byte[]! data, byte len, ushort ppuAddress) -> void
-static NES.NESLib.one_vram_buffer(byte data, ushort ppuAddress) -> void
-static NES.NESLib.set_music_speed(byte tempo) -> void
-static NES.NESLib.set_scroll_x(ushort x) -> void
-static NES.NESLib.set_scroll_y(ushort y) -> void


### PR DESCRIPTION
🤖 Prepares for the 0.3.3 release by bumping the version and promoting all currently unshipped public API surface to shipped.

**Changes:**

- `Directory.Build.props`: Version 0.3.2 -> 0.3.3
- `neslib/PublicAPI`: Moved all ten unshipped entries to shipped
- No analyzer release update is needed because `AnalyzerReleases.Unshipped.md` has no pending rules
