### PR TITLE
Disable dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # gh-aw lock files must be updated via `gh aw compile`, not individual
-      # SHA bumps. Partial version bumps break the workflow.
-      - dependency-name: "github/gh-aw-actions"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:


### PR DESCRIPTION
Removes the `github-actions` package ecosystem from `.github/dependabot.yml`, so dependabot will no longer open weekly PRs bumping action versions.

NuGet updates are unchanged and still run weekly.